### PR TITLE
Update 02-variables.mkd

### DIFF
--- a/book/02-variables.mkd
+++ b/book/02-variables.mkd
@@ -165,9 +165,9 @@ Python reserves 33 keywords:
 
     and       del       from      None      True
     as        elif      global    nonlocal  try
-    assert    else      if        not       with
-    break     except    import    or        yield
-    class     False     in        pass
+    assert    else      if        not       while
+    break     except    import    or        with
+    class     False     in        pass      yield
     continue  finally   is        raise
     def       for       lambda    return
 

--- a/book/02-variables.mkd
+++ b/book/02-variables.mkd
@@ -161,15 +161,15 @@ the structure of the program, and they cannot be used as variable names.
 
 \index{keyword}
 
-Python reserves 31 keywords:
+Python reserves 33 keywords:
 
-    and       del       global    not       while
-    as        elif      if        or        with
-    assert    else      import    pass      yield
-    break     except    in        print
-    class     finally   is        raise
-    continue  for       lambda    return
-    def       from      nonlocal  try
+    and       del       from      None      True
+    as        elif      global    nonlocal  try
+    assert    else      if        not       with
+    break     except    import    or        yield
+    class     False     in        pass
+    continue  finally   is        raise
+    def       for       lambda    return
 
 You might want to keep this list handy. If the interpreter complains
 about one of your variable names and you don't know why, see if it is on


### PR DESCRIPTION
Python 3 reserves 33 keywords (instead of 31 keywords)
"True" , "False" , "None" are added.
"print" is no longer a keyword.