### PR TITLE
VerbatimInput for file includes?

### DIFF
--- a/book/01-intro.mkd
+++ b/book/01-intro.mkd
@@ -560,6 +560,10 @@ I am giving it to you to use so you can save some time.
             bigcount = count
 
     print(bigword, bigcount)
+    
+Fancy verbatim input for comparison:
+
+\VerbatimInput{../code3/words.py}
 
 You don't even need to know Python to use this program. You will need to
 get through Chapter 10 of this book to fully understand the awesome

--- a/book/template.latex
+++ b/book/template.latex
@@ -78,8 +78,10 @@ $endif$
 $if(highlighting-macros)$
 $highlighting-macros$
 $endif$
-$if(verbatim-in-note)$
 \usepackage{fancyvrb}
+\RecustomVerbatimCommand{\VerbatimInput}{VerbatimInput}%
+{fontsize=\small}
+$if(verbatim-in-note)$
 \VerbatimFootnotes
 $endif$
 $if(tables)$


### PR DESCRIPTION
In the spirit of DRY, wondering if you'd consider VerbatimInput for including .py files?

Here's what I get when I compile this quick example with `book.sh`:
![screenshot 2016-01-06 at 7 57 29 am](https://cloud.githubusercontent.com/assets/1702745/12143082/654d7f46-b44b-11e5-960c-6e1ead810818.png)

Besides avoiding the possibility of code files that differ from what's written in the book, this will make adding interactivity easier in the future :)

Downside: It makes the tex source less readable