### PR TITLE
Forward compatibility with pandoc >1.14

### DIFF
--- a/book/template.latex
+++ b/book/template.latex
@@ -140,6 +140,10 @@ $endif$
 
 \newcommand{\verbatimfont}[1]{\def\verbatim@font{#1}}%
 
+% Forwards compatibility with pandoc >1.14
+\providecommand{\tightlist}{%
+  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+  
 $if(title)$
 \title{$title$$if(subtitle)$\\\vspace{0.5em}{\large $subtitle$}$endif$}
 $endif$


### PR DESCRIPTION
This little latex diddie will let our book build for pandoc 1.14 and up.  Ubuntu apt is on 1.12 so many folks won't notice, but the current template throws an error on 1.16 (I installed the deb).

I don't imagine this will break backwards compatibility but worth someone with 1.12 checking before merge.

More here:
https://github.com/jgm/pandoc/pull/1571#issuecomment-106298268