### PR TITLE
Update urllink2.py

### DIFF
--- a/code3/urllink2.py
+++ b/code3/urllink2.py
@@ -1,13 +1,13 @@
 # install beautifulsoup4 
 # https://pypi.python.org/pypi/beautifulsoup4
 
-import urllib.request, urllib.parse, urllib.error
+import urllib.request
 from bs4 import BeautifulSoup
 
 url = input('Enter - ')
 html = urllib.request.urlopen(url).read()
 
-soup = BeautifulSoup(html, "lxml")
+soup = BeautifulSoup(html, "html.parser")
 
 # Retrieve all of the anchor tags
 tags = soup('a')


### PR DESCRIPTION
Remove extra imports from 2to3 auto conversion - urllib.parse, urllib.error

urllink2.py used in Wk4 Chap 12 Scrape Numbers and Book section 9.7 are HTML input.

Change parser to html, not lxml which will be an error. See Issues Code conversion checklist #60

Try it, and reproduce the error in the checklist.
M:\Courses\Coursera\Notes v3 conversion>c:\python35\python urllink2.py3
Enter - http://www.dr-chuck.com/page1.htm
Traceback (most recent call last):
  File "urllink2.py3", line 10, in <module>
    soup = BeautifulSoup(html, "lxml")
  File "c:\python35\lib\site-packages\bs4\__init__.py", line 156, in __init__
    % ",".join(features))
bs4.FeatureNotFound: Couldn't find a tree builder with the features you requested: lxml. Do you need to install a parser library?

Remove the parser, 
M:\Courses\Coursera\Notes v3 conversion>c:\python35\python urllink2.py3
Enter - http://www.dr-chuck.com/page1.htm
c:\python35\lib\site-packages\bs4\__init__.py:166: UserWarning: No parser was explicitly specified, so I'm using the best available HT
L parser for this system ("html.parser"). This usually isn't a problem, but if you run this code on another system, or in a different
irtual environment, it may use a different parser and behave differently.

To get rid of this warning, change this:

 BeautifulSoup([your markup])

to this:

 BeautifulSoup([your markup], "html.parser")