### PR TITLE
The code doesn't work when only the translate argument change is made

### DIFF
--- a/code3/count2.py
+++ b/code3/count2.py
@@ -9,7 +9,8 @@ except:
 
 counts = dict()
 for line in fhand:
-    line = line.translate(string.punctuation)
+    line = line.rstrip()
+    line = line.translate(line.maketrans('','',string.punctuation))
     line = line.lower()
     words = line.split()
     for word in words:


### PR DESCRIPTION
Code had translate modified to 1 argument from v2 (None, string.punctuation). The output is not the same as v2, the punctuation is not removed, and line breaks are left in.

Test
>>> import string
>>> line = "found, return a 3-tuple containing the string itself, followed by two empty strings."

v3.5.1
>>> line = line.translate(None, string.punctuation)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: translate() takes exactly one argument (2 given)
>>>

>>> line.translate(string.punctuation)
'found, return a 3-tuple containing the string itself, followed by two empty strings.'

the output didn't change Run both versions of code and look at the dictionaries they are different. 

v2.7.11
>>> line.translate(None, string.punctuation)
'found return a 3tuple containing the string itself followed by two empty strings'
>>>

v3 fix
>>> line.translate(line.maketrans('','',string.punctuation))
'found return a 3tuple containing the string itself followed by two empty strings'


Another fix required in v3, use romeo.txt for less words, and sorted() to check dict, the files have UNIX EOLs and you get this. Also used editor to convert EOL Unix/MAC to DOS still adds EOLs as + in output.

['already', 'and', 'arise', 'breaks+', 'but', 'east', 'envious', 'fair', 'grief+', 'is', 'it', 'juliet', 'kill', 'light', 'moon+', 'pale', 'sick', 'soft', 'sun', 'sun+', 'the', 'through', 'what', 'who', 'window', 'with', 'yonder']

It may be a good idea to switch to .read() and .splitlines(), but for now what's in the course, .rstrip() works.

>>> t = fh.read()
>>> t.splitlines()
['But soft what light through yonder window breaks', 'It is the east and Juliet is the sun', 'Arise fair sun and kill the envious moon', 'Who is already sick and pale with grief']
>>>

Also added sorted(counts) to test code for a quick visual check both v2/v3 outputs are the same. 