### PR TITLE
hello.py source made Python 3 compliant

### DIFF
--- a/book/01-intro.mkd
+++ b/book/01-intro.mkd
@@ -509,7 +509,7 @@ of the file. In a Unix or Windows command window, you would type
 
 ~~~~ {.bash}
     csev$ cat hello.py
-    print 'Hello world!'
+    print('Hello world!')
     csev$ python hello.py
     Hello world!
     csev$


### PR DESCRIPTION
In the section Writing a program (Chapter 1) changed to include parenthesis in the call to 'print' to be Python 3 compliant. (print is a command, not a statement in Python 3)

Note: Currently chapter 1 and 2 have several references to the `print` statement (instead of the Python 3 `print` command) and the figures have examples of the Python 2 `print` statement throughout.