### PR TITLE
Em-dash fix, ch. 8

### DIFF
--- a/book/08-lists.mkd
+++ b/book/08-lists.mkd
@@ -68,7 +68,7 @@ Lists are mutable
 \index{operator!bracket}
 
 The syntax for accessing the elements of a list is the same as for
-accessing the characters of a string—the bracket operator. The
+accessing the characters of a string: the bracket operator. The
 expression inside the brackets specifies the index. Remember that the
 indices start at 0:
 


### PR DESCRIPTION
Replaced em-dash with colon in line 71.